### PR TITLE
Compose + ViewModel 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     implementation "androidx.compose.ui:ui:$compose_ui_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_ui_version"
     implementation 'androidx.compose.material:material:1.1.1'
+
+    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1"
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/main/java/com/example/composetodoapp/MainActivity.kt
+++ b/app/src/main/java/com/example/composetodoapp/MainActivity.kt
@@ -3,21 +3,21 @@ package com.example.composetodoapp
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.example.composetodoapp.model.Note
 import com.example.composetodoapp.screen.NoteScreen
 import com.example.composetodoapp.ui.theme.ComposeTodoAppTheme
 
 @ExperimentalComposeUiApi
 class MainActivity : ComponentActivity() {
+    private val noteViewModel: NoteViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
@@ -26,19 +26,29 @@ class MainActivity : ComponentActivity() {
                 Surface(
                     modifier = Modifier.fillMaxSize(), color = MaterialTheme.colors.background
                 ) {
-                    val notes = remember {
-                        mutableStateListOf<Note>()
-                    }
-
-                    NoteScreen(notes = notes, onAddNote = {
-                        notes.add(it)
-                    }, onRemoteNote = {
-                        notes.remove(it)
-                    })
+                    NotesApp(noteViewModel = noteViewModel)
                 }
             }
         }
     }
+}
+
+@ExperimentalComposeUiApi
+@Composable
+fun NotesApp(noteViewModel: NoteViewModel) {
+    /**
+     * state holder -> NotesApp()
+     * 실제 UI를 그리는 Composable -> NoteScreen()
+     * --------------- 설명 ---------------------
+     * UI를 직접 그리는 NoteScreen Composable 에는 ViewModel 을 직접 주입하지 않고,
+     * state holder 를 담당하는 Composable 을 한 단계 거치도록 함
+     */
+    val noteList = noteViewModel.getAllNotes()
+    NoteScreen(
+        notes = noteList,
+        onAddNote = noteViewModel::addNote,
+        onRemoteNote = noteViewModel::removeNote
+    )
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/com/example/composetodoapp/NoteViewModel.kt
+++ b/app/src/main/java/com/example/composetodoapp/NoteViewModel.kt
@@ -1,0 +1,21 @@
+package com.example.composetodoapp
+
+import androidx.compose.runtime.mutableStateListOf
+import androidx.lifecycle.ViewModel
+import com.example.composetodoapp.model.Note
+
+class NoteViewModel : ViewModel() {
+    private var noteList = mutableStateListOf<Note>()
+
+    fun addNote(note: Note) {
+        noteList.add(note)
+    }
+
+    fun removeNote(note: Note) {
+        noteList.remove(note)
+    }
+
+    fun getAllNotes(): List<Note> {
+        return noteList
+    }
+}


### PR DESCRIPTION
## 🍎 Compose 에 ViewModel 추가
- ♠️ `Compose` 에서는 `State` 변화 시에 해당 `State` 와 연결된 `Composable` 이 `Recomposition` 을 거치기 때문에 `ViewModel` 에서 `State` 와 이를 업데이트하는 함수를 직접 선언하게 하고, `Composable` 함수 매개변수로 ViewModel 을 받아 사용하면 된다.
> ❗️주의❗️
> - `ViewModel` 에서 `State` 를 선언할 때는 `remember` 를 사용하지 않는다.
> - UI를 직접 그리는 `Composable` 에는 `ViewModel` 을 직접 주입하지 않고, `state holder` 를 담당하는 `Composable` 을 한 단계 거치도록 한다
>> 만약 실제 UI를 그리는 `Composable` 에 직접 `ViewModel` 을 전달하면 `Preview` 사용이 어려워지고, `Test` 가능성이 떨어진다.