### PR TITLE
Compose Navigation 적용

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-kapt'
     id 'dagger.hilt.android.plugin'
+    id 'kotlin-parcelize'
 }
 
 android {
@@ -71,6 +72,8 @@ dependencies {
 
     implementation "androidx.compose.material:material-icons-extended:1.2.1"
     implementation "androidx.compose.material:material-icons-core:1.2.1"
+
+    implementation "androidx.navigation:navigation-compose:2.5.2"
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/src/main/java/com/example/composetodoapp/domain/model/Note.kt
+++ b/app/src/main/java/com/example/composetodoapp/domain/model/Note.kt
@@ -1,12 +1,14 @@
 package com.example.composetodoapp.domain.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 import org.joda.time.DateTime
-import java.time.Instant
 import java.util.*
 
+@Parcelize
 data class Note(
     val id: UUID = UUID.randomUUID(),
     val title: String,
     val description: String,
     val entryDate: DateTime = DateTime.now()
-)
+): Parcelable

--- a/app/src/main/java/com/example/composetodoapp/presentation/navigation/NavigationType.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/navigation/NavigationType.kt
@@ -1,0 +1,6 @@
+package com.example.composetodoapp.presentation.navigation
+
+enum class NavigationType {
+    HOMESCREEN,
+    DETAILSCREEN
+}

--- a/app/src/main/java/com/example/composetodoapp/presentation/navigation/NoteNavigation.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/navigation/NoteNavigation.kt
@@ -1,0 +1,38 @@
+package com.example.composetodoapp.presentation.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.example.composetodoapp.presentation.screen.NoteDetailScreen
+import com.example.composetodoapp.presentation.screen.NoteScreen
+import com.example.composetodoapp.presentation.ui.NoteViewModel
+import kotlinx.coroutines.CoroutineScope
+
+@ExperimentalComposeUiApi
+@Composable
+fun NoteNavigation(viewModel: NoteViewModel, coroutineScope: CoroutineScope) {
+    val navController = rememberNavController()
+    val notes = viewModel.requestGetAllNoteList.collectAsState()
+
+    return NavHost(navController = navController, startDestination = NavigationType.HOMESCREEN.name) {
+        composable(NavigationType.HOMESCREEN.name) {
+            NoteScreen(
+                navController = navController,
+                notes = notes.value,
+                onAddNote = viewModel::addNote,
+                onRemoveNote = viewModel::removeNote,
+                onRemoveAll = viewModel::removeAllNote,
+                coroutineScope = coroutineScope
+            )
+        }
+
+        composable(
+            route = NavigationType.DETAILSCREEN.name,
+        ) {
+            NoteDetailScreen(navController = navController)
+        }
+    }
+}

--- a/app/src/main/java/com/example/composetodoapp/presentation/screen/NoteDetailScreen.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/screen/NoteDetailScreen.kt
@@ -1,0 +1,26 @@
+package com.example.composetodoapp.presentation.screen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+
+@Composable
+fun NoteDetailScreen(navController: NavController) {
+    Column(
+        modifier = Modifier
+            .fillMaxHeight()
+            .fillMaxHeight()
+    ) {
+
+        Text(text = "test")
+        Text(text = "description")
+        Text(text = "test22344")
+        Button(onClick = { navController.popBackStack() }) {
+            Text(text = "종료")
+        }
+    }
+}

--- a/app/src/main/java/com/example/composetodoapp/presentation/screen/NoteScreen.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/screen/NoteScreen.kt
@@ -17,15 +17,18 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 import com.example.composetodoapp.R
 import com.example.composetodoapp.domain.model.Note
 import com.example.composetodoapp.presentation.components.*
+import com.example.composetodoapp.presentation.navigation.NavigationType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 @ExperimentalComposeUiApi
 @Composable
 fun NoteScreen(
+    navController: NavController,
     notes: List<Note>,
     onAddNote: (Note) -> Unit,
     onRemoveNote: (Note) -> Unit,
@@ -165,7 +168,7 @@ fun NoteScreen(
                     NoteRow(
                         note = note,
                         onNoteClicked = {
-                            // TODO: 상세화면으로 이동 -> BottomSheet 띄울 것
+                            navController.navigate(route = NavigationType.DETAILSCREEN.name)
                         },
                         onRemoveNoteClick = {
                             showDialog.value = true to it

--- a/app/src/main/java/com/example/composetodoapp/presentation/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/ui/MainActivity.kt
@@ -4,16 +4,11 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.lifecycleScope
-import com.example.composetodoapp.presentation.screen.NoteScreen
+import com.example.composetodoapp.presentation.navigation.NoteNavigation
 import com.example.composetodoapp.presentation.theme.ComposeTodoAppTheme
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -27,12 +22,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             ComposeTodoAppTheme {
-                // A surface container using the 'background' color from the theme
-                Surface(
-                    modifier = Modifier.fillMaxSize(), color = MaterialTheme.colors.background
-                ) {
-                    NotesApp(noteViewModel = noteViewModel, lifecycleScope)
-                }
+                NotesApp(noteViewModel = noteViewModel, lifecycleScope)
             }
         }
     }
@@ -48,15 +38,7 @@ fun NotesApp(noteViewModel: NoteViewModel, coroutineScope: CoroutineScope) {
      * UI를 직접 그리는 NoteScreen Composable 에는 ViewModel 을 직접 주입하지 않고,
      * state holder 를 담당하는 Composable 을 한 단계 거치도록 함
      */
-    val noteList = noteViewModel.requestGetAllNoteList.collectAsState()
-
-    NoteScreen(
-        notes = noteList.value,
-        onAddNote = noteViewModel::addNote,
-        onRemoveNote = noteViewModel::removeNote,
-        onRemoveAll = noteViewModel::removeAllNote,
-        coroutineScope
-    )
+    NoteNavigation(noteViewModel, coroutineScope)
 }
 
 @Preview(showBackground = true)


### PR DESCRIPTION
## 🍎 Compose Navigation 적용
### 🚩 1. Compose Navigation + ViewModel
- Compose Navigation Composable 함수 파라미터에서 ViewModel 을 받아와 사용

### 🚩 2. Compose Navigation
- `remeberNavController` 를 통해 NavController 를 만듬
-  `NavHost` 함수를 통해 navController 를 연결하고, 처음 보여줄 화면 `startDestination` 을 설정
  - `NavHost` 마지막 인자는 NavGraph Builder 함수로 내부에 `composable` 를 통해 `navigation`에서 사용될 Screen 등록

### ⚠️ 주의 ⚠️
- Navigation 이동 시 navArgument로 객체를 보내는 방법을 모르겠음
> ✔️ [참고 사이트](https://pluu.github.io/blog/android/2022/02/04/compose-pending-argument-part-2/)