### PR TITLE
Compose Navigation 에 Custom Dialog 적용

### DIFF
--- a/app/src/main/java/com/example/composetodoapp/presentation/components/CustomDialog.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/components/CustomDialog.kt
@@ -1,5 +1,6 @@
 package com.example.composetodoapp.presentation.components
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -10,88 +11,106 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
+import androidx.navigation.NavController
+import com.example.composetodoapp.presentation.navigation.NavigationType
 
 @Composable
 fun CustomDialog(
+    navController: NavController,
     value: String,
-    setShowDialog: (Boolean) -> Unit,
+    @StringRes valueRes: Int? = null,
+    @StringRes confirmText: Int,
+    @StringRes cancelText: Int,
     onConfirmClick: () -> Unit,
 ) {
-
-    Dialog(onDismissRequest = { setShowDialog(false) }) {
-        Surface(
-            shape = RoundedCornerShape(16.dp), color = Color.White
-        ) {
-            Box(contentAlignment = Alignment.Center) {
-                Column {
-                    Row(
+    Surface(
+        shape = RoundedCornerShape(16.dp), color = Color.White
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Column {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(10.dp),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    Icon(imageVector = Icons.Filled.Cancel,
+                        contentDescription = "",
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(10.dp),
-                        horizontalArrangement = Arrangement.End,
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.Cancel,
-                            contentDescription = "",
-                            modifier = Modifier
-                                .width(30.dp)
-                                .height(30.dp)
-                                .clickable { setShowDialog(false) }
+                            .width(30.dp)
+                            .height(30.dp)
+                            .clickable { navController.popBackStack() })
+                }
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(10.dp),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = if (valueRes != null) {
+                            stringResource(id = valueRes, value)
+                        } else {
+                            value
+                        }, style = TextStyle(
+                            fontSize = 24.sp,
+                            fontFamily = FontFamily.Default,
+                            fontWeight = FontWeight.Bold
                         )
-                    }
-                    Row(
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(20.dp)
+                ) {
+                    Button(
+                        onClick = {
+                            navController.popBackStack()
+                            /**
+                             * navController.currentBackStackEntry?.destination?.route
+                             * -> 현재 Navigation Route 이름 가져오기
+                             */
+                            if (navController.currentBackStackEntry?.destination?.route == NavigationType.DETAILSCREEN.name) {
+                                navController.popBackStack()
+                            }
+                            onConfirmClick()
+                        },
+                        shape = RoundedCornerShape(50.dp),
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(10.dp),
-                        horizontalArrangement = Arrangement.Center,
-                        verticalAlignment = Alignment.CenterVertically
+                            .height(50.dp)
+                            .padding(end = 10.dp)
+                            .weight(1f)
+                    ) {
+                        Text(text = stringResource(id = confirmText))
+                    }
+                    Button(
+                        onClick = {
+                            navController.popBackStack()
+                        },
+                        shape = RoundedCornerShape(50.dp),
+                        modifier = Modifier
+                            .height(50.dp)
+                            .padding(start = 10.dp)
+                            .weight(1f),
+                        colors = ButtonDefaults.buttonColors(
+                            backgroundColor = Color.White,
+                            contentColor = Color.Black,
+                        )
                     ) {
                         Text(
-                            text = value, style = TextStyle(
-                                fontSize = 24.sp,
-                                fontFamily = FontFamily.Default,
-                                fontWeight = FontWeight.Bold
-                            )
+                            text = stringResource(id = cancelText), style = TextStyle(color = Color.Black)
                         )
-                    }
-
-                    Spacer(modifier = Modifier.height(20.dp))
-
-                    Row(modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(20.dp)) {
-                        Button(
-                            onClick = onConfirmClick,
-                            shape = RoundedCornerShape(50.dp),
-                            modifier = Modifier
-                                .height(50.dp)
-                                .padding(end = 10.dp)
-                                .weight(1f)
-                        ) {
-                            Text(text = "삭제")
-                        }
-                        Button(
-                            onClick = {
-                                setShowDialog(false)
-                            },
-                            shape = RoundedCornerShape(50.dp),
-                            modifier = Modifier
-                                .height(50.dp)
-                                .padding(start = 10.dp)
-                                .weight(1f),
-                            colors = ButtonDefaults.buttonColors(
-                                backgroundColor = Color.White,
-                                contentColor = Color.Black,
-                            )
-                        ) {
-                            Text(text = "취소", style = TextStyle(color = Color.Black))
-                        }
                     }
                 }
             }

--- a/app/src/main/java/com/example/composetodoapp/presentation/navigation/NavigationType.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/navigation/NavigationType.kt
@@ -2,5 +2,6 @@ package com.example.composetodoapp.presentation.navigation
 
 enum class NavigationType {
     HOMESCREEN,
-    DETAILSCREEN
+    DETAILSCREEN,
+    CUSTOMDIALOG
 }

--- a/app/src/main/java/com/example/composetodoapp/presentation/navigation/NoteNavigation.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/navigation/NoteNavigation.kt
@@ -1,22 +1,37 @@
 package com.example.composetodoapp.presentation.navigation
 
+import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.window.DialogProperties
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.dialog
 import androidx.navigation.compose.rememberNavController
+import com.example.composetodoapp.R
+import com.example.composetodoapp.presentation.components.CustomDialog
 import com.example.composetodoapp.presentation.screen.NoteDetailScreen
 import com.example.composetodoapp.presentation.screen.NoteScreen
 import com.example.composetodoapp.presentation.ui.NoteViewModel
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 @ExperimentalComposeUiApi
 @Composable
 fun NoteNavigation(viewModel: NoteViewModel, coroutineScope: CoroutineScope) {
     val navController = rememberNavController()
+    // SnackBar
+    val scaffoldState = rememberScaffoldState()
+
+    // Note
     val notes = viewModel.requestGetAllNoteList.collectAsState()
     val note = viewModel.currentNote.collectAsState()
+
+    // CustomDialog
+    val customDialogTitle = viewModel.customDialogTitle.collectAsState()
+    val customDialogConfirmText = viewModel.customDialogConfirmText.collectAsState()
+    val customDialogCancelText = viewModel.customDialogCancelText.collectAsState()
 
     return NavHost(navController = navController, startDestination = NavigationType.HOMESCREEN.name) {
         composable(NavigationType.HOMESCREEN.name) {
@@ -24,17 +39,55 @@ fun NoteNavigation(viewModel: NoteViewModel, coroutineScope: CoroutineScope) {
                 navController = navController,
                 notes = notes.value,
                 onAddNote = viewModel::addNote,
-                onRemoveNote = viewModel::removeNote,
-                onRemoveAll = viewModel::removeAllNote,
                 coroutineScope = coroutineScope,
                 setCurrentNote = viewModel::setCurrentNote,
+                scaffoldState = scaffoldState,
+                setCustomDialogCancelText = viewModel::setCustomDialogCancelText,
+                setCustomDialogConfirmText = viewModel::setCustomDialogConfirmText,
+                setCustomDialogTitle = viewModel::setCustomDialogTitle
             )
         }
 
         composable(
             route = NavigationType.DETAILSCREEN.name,
         ) {
-            NoteDetailScreen(navController = navController, note.value, viewModel::removeNote)
+            NoteDetailScreen(
+                navController = navController,
+                note.value,
+                setCustomDialogCancelText = viewModel::setCustomDialogCancelText,
+                setCustomDialogConfirmText = viewModel::setCustomDialogConfirmText,
+                setCustomDialogTitle = viewModel::setCustomDialogTitle,
+                setCurrentNote = viewModel::setCurrentNote,
+            )
+        }
+
+        dialog(
+            route = NavigationType.CUSTOMDIALOG.name,
+            dialogProperties = DialogProperties(
+                dismissOnBackPress = true,
+                dismissOnClickOutside = true,
+            )
+        ) {
+            CustomDialog(
+                navController = navController,
+                value = customDialogTitle.value.first,
+                valueRes= customDialogTitle.value.second,
+                confirmText = customDialogConfirmText.value,
+                cancelText = customDialogCancelText.value,
+            ) {
+                coroutineScope.launch {
+                    if (customDialogTitle.value.second == R.string.dialog_all_remove_title) {
+                        viewModel.removeAllNote()
+                        scaffoldState.snackbarHostState.showSnackbar("전체 메모를 삭제하였습니다.")
+                        return@launch
+                    }
+
+                    viewModel.currentNote.value?.let {
+                        viewModel.removeNote(it)
+                        scaffoldState.snackbarHostState.showSnackbar("${it.title}를 삭제하였습니다.")
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/composetodoapp/presentation/screen/NoteDetailScreen.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/screen/NoteDetailScreen.kt
@@ -17,10 +17,18 @@ import androidx.navigation.NavController
 import com.example.composetodoapp.R
 import com.example.composetodoapp.domain.model.Note
 import com.example.composetodoapp.presentation.components.NoteDetailContentView
+import com.example.composetodoapp.presentation.navigation.NavigationType
 import com.example.composetodoapp.presentation.utils.timeFormatter
 
 @Composable
-fun NoteDetailScreen(navController: NavController, note: Note?, onDeleteNote: (Note) -> Unit) {
+fun NoteDetailScreen(
+    navController: NavController,
+    note: Note?,
+    setCustomDialogTitle: (Pair<String, Int?>) -> Unit,
+    setCustomDialogConfirmText: (Int) -> Unit,
+    setCustomDialogCancelText: (Int) -> Unit,
+    setCurrentNote: (Note) -> Unit,
+) {
     note?.let { data ->
         val title = data.title
         val description = data.description
@@ -38,8 +46,11 @@ fun NoteDetailScreen(navController: NavController, note: Note?, onDeleteNote: (N
                 }
             }, actions = {
                 IconButton(onClick = {
-                    onDeleteNote(data)
-                    navController.popBackStack()
+                    setCurrentNote(data)
+                    setCustomDialogTitle(data.title to R.string.dialog_title)
+                    setCustomDialogConfirmText(R.string.str_delete)
+                    setCustomDialogCancelText(R.string.str_cancel)
+                    navController.navigate(route = NavigationType.CUSTOMDIALOG.name)
                 }) {
                     Icon(
                         imageVector = Icons.Default.Delete,

--- a/app/src/main/java/com/example/composetodoapp/presentation/screen/NoteScreen.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/screen/NoteScreen.kt
@@ -31,54 +31,18 @@ fun NoteScreen(
     navController: NavController,
     notes: List<Note>,
     onAddNote: (Note) -> Unit,
-    onRemoveNote: (Note) -> Unit,
-    onRemoveAll: () -> Unit,
     coroutineScope: CoroutineScope,
-    setCurrentNote: (Note) -> Unit
+    setCurrentNote: (Note) -> Unit,
+    scaffoldState: ScaffoldState,
+    setCustomDialogTitle: (Pair<String, Int?>) -> Unit,
+    setCustomDialogConfirmText: (Int) -> Unit,
+    setCustomDialogCancelText: (Int) -> Unit
 ) {
     val title = remember {
         mutableStateOf("")
     }
     val description = remember {
         mutableStateOf("")
-    }
-    val showDialog = remember {
-        mutableStateOf<Pair<Boolean, Note?>>(false to null)
-    }
-
-    val showAllRemoveDialog = remember {
-        mutableStateOf(false)
-    }
-
-    val scaffoldState = rememberScaffoldState()
-
-    if (showDialog.value.first) {
-        showDialog.value.second?.let { note ->
-            CustomDialog(value = stringResource(id = R.string.dialog_title, note.title),
-                setShowDialog = {
-                    showDialog.value = it to null
-                },
-                onConfirmClick = {
-                    onRemoveNote(note)
-                    showDialog.value = false to null
-                    coroutineScope.launch {
-                        scaffoldState.snackbarHostState.showSnackbar("${note.title}를 삭제하였습니다.")
-                    }
-                })
-        }
-    }
-
-    if (showAllRemoveDialog.value) {
-        CustomDialog(value = stringResource(id = R.string.dialog_all_remove_title),
-            setShowDialog = {
-                showAllRemoveDialog.value = it
-            }) {
-            onRemoveAll()
-            showAllRemoveDialog.value = false
-            coroutineScope.launch {
-                scaffoldState.snackbarHostState.showSnackbar("전체 메모를 삭제하였습니다.")
-            }
-        }
     }
 
     // 현재 소프트웨어 키보드를 제어할 수 있는 SoftwareKeyboardController 를 반환
@@ -160,7 +124,10 @@ fun NoteScreen(
                     modifier = Modifier.padding(end = 10.dp)
                 )
                 DeleteView(text = "전체 삭제", enabled = notes.isNotEmpty()) {
-                    showAllRemoveDialog.value = true
+                    setCustomDialogTitle("" to R.string.dialog_all_remove_title)
+                    setCustomDialogConfirmText(R.string.str_delete)
+                    setCustomDialogCancelText(R.string.str_cancel)
+                    navController.navigate(route = NavigationType.CUSTOMDIALOG.name)
                 }
             }
 
@@ -173,7 +140,11 @@ fun NoteScreen(
                             navController.navigate(route = NavigationType.DETAILSCREEN.name)
                         },
                         onRemoveNoteClick = {
-                            showDialog.value = true to it
+                            setCurrentNote(it)
+                            setCustomDialogTitle(it.title to R.string.dialog_title)
+                            setCustomDialogConfirmText(R.string.str_delete)
+                            setCustomDialogCancelText(R.string.str_cancel)
+                            navController.navigate(route = NavigationType.CUSTOMDIALOG.name)
                         }
                     )
                 }

--- a/app/src/main/java/com/example/composetodoapp/presentation/ui/NoteViewModel.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/ui/NoteViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.composetodoapp.presentation.ui
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.composetodoapp.domain.model.Note
@@ -22,6 +23,27 @@ class NoteViewModel @Inject constructor(
     private val requestSaveNoteUseCase: RequestSaveNoteUseCase,
     private val requestUpdateNoteUseCase: RequestUpdateNoteUseCase
 ) : ViewModel() {
+
+    private val _customDialogTitle = MutableStateFlow<Pair<String, Int?>>("" to null)
+    val customDialogTitle = _customDialogTitle.asStateFlow()
+
+    fun setCustomDialogTitle(dialogTitle: Pair<String, Int?>) {
+        _customDialogTitle.value = dialogTitle
+    }
+
+    private val _customDialogConfirmText = MutableStateFlow(0)
+    val customDialogConfirmText = _customDialogConfirmText.asStateFlow()
+
+    fun setCustomDialogConfirmText(@StringRes confirmText: Int) {
+        _customDialogConfirmText.value = confirmText
+    }
+
+    private val _customDialogCancelText = MutableStateFlow(0)
+    val customDialogCancelText = _customDialogCancelText.asStateFlow()
+
+    fun setCustomDialogCancelText(@StringRes cancelText: Int) {
+        _customDialogCancelText.value = cancelText
+    }
 
     private val _currentNote = MutableStateFlow<Note?>(null)
     val currentNote = _currentNote.asStateFlow()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,7 @@
     <string name="note_detail_title">%1$s 노트 상세</string>
     <string name="note_create_at">작성 : %1$s</string>
     <string name="note_update_at">수정 : %1$s</string>
+    <string name="delete_note">$1$s를 삭제 하였습니다.</string>
+    <string name="str_cancel">취소</string>
+    <string name="str_delete">삭제</string>
 </resources>


### PR DESCRIPTION
## 🍎 Compose Navigation 에 Custom Dialog 적용
### 🚩 NavHost 에서 dialog 적용
- `navHost` 블럭 안에서 compose navigation `dialog` 함수를 사용하여 구현
- **✅ 참고** 👉 하나의 dialog로 각각 다른 파라미터를 받아 사용해야 하는데 `navArgument()`를 사용하지 않고 ViewModel 을 사용하여 처리

### 🚩 현재 Navigation Route 위치 가져오기
- 문제 : NoteDetailScreen -> CustomDialog 로 이동 -> 삭제 버튼 클릭 시 `navController.popBackStack()` 하면 CustomDialog 만 BackStack 되고 NoteDetailScreen 은 BackStack 되지 않음
- 해결
  - 1. `ViewModel` 을 사용하여 삭제 버튼 클릭 후 완료되면 Event 받아서 처리
  - 2. `Navigation Route` 위치를 가져와 비교하여 CustomDialog popBackStack 이후 현재 Route 위치가 NoteDetailScreen 인 경우 한번 더 `navController.popBackStack()` 을 하여 종료하는 방식으로 처리
> 샘플 코드👇
>> 
``` Kotlin
onClick {
    navController.popBackStack() 
    if (navController.currentBackStackEntry?.destination?.route == NavigationType.DETAILSCREEN.name) { 
        navController.popBackStack() 
    } 

    onConfirmClick() 
}
```