### PR TITLE
노트 상세 InputText 추가

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <runningDeviceTargetSelectedWithDropDown>
+      <Target>
+        <type value="RUNNING_DEVICE_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="VIRTUAL_DEVICE_PATH" />
+            <value value="$USER_HOME$/.android/avd/Pixel_3a_API_33_arm64-v8a.avd" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2022-10-04T00:38:59.026513Z" />
+  </component>
+</project>

--- a/app/src/main/java/com/example/composetodoapp/data/database/dao/NoteDao.kt
+++ b/app/src/main/java/com/example/composetodoapp/data/database/dao/NoteDao.kt
@@ -20,7 +20,7 @@ interface NoteDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(noteEntity: NoteEntity)
 
-    @Update(onConflict = OnConflictStrategy.REPLACE)
+    @Update
     suspend fun update(noteEntity: NoteEntity)
 
     @Query("DELETE FROM `note`")

--- a/app/src/main/java/com/example/composetodoapp/data/database/entity/NoteEntity.kt
+++ b/app/src/main/java/com/example/composetodoapp/data/database/entity/NoteEntity.kt
@@ -6,17 +6,19 @@ import androidx.room.PrimaryKey
 import androidx.room.TypeConverters
 import com.example.composetodoapp.data.database.converter.DateTimeConverter
 import org.joda.time.DateTime
-import java.util.UUID
 
 @Entity(tableName = "note")
 data class NoteEntity(
-    @PrimaryKey
-    val id: UUID = UUID.randomUUID(),
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0L,
     @ColumnInfo(name = "note_title")
     val title: String,
     @ColumnInfo(name = "note_description")
     val description: String,
     @field:TypeConverters(DateTimeConverter::class)
     @ColumnInfo(name = "note_entry_date")
-    val entryDate: DateTime = DateTime.now()
+    val entryDate: DateTime = DateTime.now(),
+    @field:TypeConverters(DateTimeConverter::class)
+    @ColumnInfo(name = "note_update_date")
+    val updateDate: DateTime? = null
 )

--- a/app/src/main/java/com/example/composetodoapp/data/mapper/ObjectMapper.kt
+++ b/app/src/main/java/com/example/composetodoapp/data/mapper/ObjectMapper.kt
@@ -4,11 +4,19 @@ import com.example.composetodoapp.data.database.entity.NoteEntity
 import com.example.composetodoapp.domain.model.Note
 
 fun Note.toNoteEntity(): NoteEntity = NoteEntity(
-    id = this.id, title = this.title, description = this.description, entryDate = this.entryDate
+    id = this.id,
+    title = this.title,
+    description = this.description,
+    entryDate = this.entryDate,
+    updateDate = this.updateDate
 )
 
 fun NoteEntity.toNote(): Note = Note(
-    id = this.id, title = this.title, description = this.description, entryDate = this.entryDate
+    id = this.id,
+    title = this.title,
+    description = this.description,
+    entryDate = this.entryDate,
+    updateDate = this.updateDate
 )
 
 fun List<NoteEntity>.toNoteList(): List<Note> = map {

--- a/app/src/main/java/com/example/composetodoapp/domain/model/Note.kt
+++ b/app/src/main/java/com/example/composetodoapp/domain/model/Note.kt
@@ -3,12 +3,12 @@ package com.example.composetodoapp.domain.model
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 import org.joda.time.DateTime
-import java.util.*
 
 @Parcelize
 data class Note(
-    val id: UUID = UUID.randomUUID(),
+    val id: Long = 0L,
     val title: String,
     val description: String,
-    val entryDate: DateTime = DateTime.now()
+    val entryDate: DateTime = DateTime.now(),
+    val updateDate: DateTime? = null
 ): Parcelable

--- a/app/src/main/java/com/example/composetodoapp/presentation/components/NoteDetailComponents.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/components/NoteDetailComponents.kt
@@ -5,9 +5,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Divider
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -17,6 +16,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -29,12 +29,15 @@ fun NoteDetailContentView(
     title: String,
     description: String,
     insertDate: String,
+    onChangeTitle: (String) -> Unit,
+    onChangeDescription: (String) -> Unit
 ) {
     Column(
         modifier = modifier
             .fillMaxHeight()
             .fillMaxWidth()
-            .padding(horizontal = 20.dp), horizontalAlignment = Alignment.CenterHorizontally
+            .padding(horizontal = 20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Surface(
             modifier = modifier
@@ -45,16 +48,10 @@ fun NoteDetailContentView(
                     )
                 )
                 .fillMaxWidth(),
-            color = Color.White,
-            border = BorderStroke(2.dp, colorResource(id = R.color.orange)),
-            shape = RoundedCornerShape(10.dp),
         ) {
-            Text(
-                modifier = modifier.padding(10.dp),
-                text = title,
-                style = TextStyle(Color.Black, fontSize = 24.sp, fontWeight = FontWeight.Bold),
-                textAlign = TextAlign.Center
-            )
+            EditTitleInput(title = title) {
+                onChangeTitle(it)
+            }
         }
 
         Row(
@@ -84,7 +81,7 @@ fun NoteDetailContentView(
                 )
             }
         }
-        
+
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -94,13 +91,13 @@ fun NoteDetailContentView(
                     BorderStroke(2.dp, colorResource(id = R.color.orange)),
                     shape = RoundedCornerShape(10.dp)
                 )
-                .background(color = Color.White)
-            ,
-            contentAlignment = Alignment.TopStart
+                .background(color = Color.White), contentAlignment = Alignment.TopStart
         ) {
-            Column(modifier = modifier
-                .fillMaxSize()
-                .padding(10.dp)) {
+            Column(
+                modifier = modifier
+                    .fillMaxSize()
+                    .padding(10.dp)
+            ) {
                 Text(
                     text = "내용",
                     style = TextStyle(Color.Black, fontWeight = FontWeight.Bold, fontSize = 20.sp),
@@ -108,21 +105,55 @@ fun NoteDetailContentView(
                 )
                 Divider(color = colorResource(id = R.color.orange))
                 Text(
-                    text = description,
-                    style = TextStyle(Color.DarkGray, fontWeight = FontWeight.Medium, fontSize = 18.sp),
-                    modifier = modifier.padding(10.dp, top = 10.dp)
+                    text = description, style = TextStyle(
+                        Color.DarkGray, fontWeight = FontWeight.Medium, fontSize = 18.sp
+                    ), modifier = modifier.padding(10.dp, top = 10.dp)
                 )
             }
         }
     }
 }
 
+@Composable
+fun EditTitleInput(
+    modifier: Modifier = Modifier, title: String, onModifyText: (String) -> Unit
+) {
+    TextField(modifier = modifier
+        .fillMaxWidth()
+        .border(
+            BorderStroke(
+                width = 2.dp, color = colorResource(R.color.orange)
+            ), shape = RoundedCornerShape(10.dp)
+        ),
+        textStyle = TextStyle(
+            Color.Black,
+            fontSize = 24.sp,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center
+        ),
+        singleLine = true,
+        colors = TextFieldDefaults.textFieldColors(
+            backgroundColor = Color.Transparent,
+            focusedIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent
+        ),
+        placeholder = {
+            Text(text = title)
+        },
+        value = title,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+        onValueChange = {
+            onModifyText(it)
+        },
+    )
+}
+
 @Preview
 @Composable
 fun NoteDetailContentViewPreview() {
-    NoteDetailContentView(
-        title = "text",
+    NoteDetailContentView(title = "text",
         description = "description",
-        insertDate = "2022 09/30 17:53"
-    )
+        insertDate = "2022 09/30 17:53",
+        onChangeTitle = {},
+        onChangeDescription = {})
 }

--- a/app/src/main/java/com/example/composetodoapp/presentation/components/NoteDetailComponents.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/components/NoteDetailComponents.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
@@ -30,7 +31,8 @@ fun NoteDetailContentView(
     description: String,
     insertDate: String,
     onChangeTitle: (String) -> Unit,
-    onChangeDescription: (String) -> Unit
+    onChangeDescription: (String) -> Unit,
+    onTitleSubmit: () -> Unit
 ) {
     Column(
         modifier = modifier
@@ -49,8 +51,8 @@ fun NoteDetailContentView(
                 )
                 .fillMaxWidth(),
         ) {
-            EditTitleInput(title = title) {
-                onChangeTitle(it)
+            EditTitleInput(title = title, onModifyText = onChangeTitle) {
+                onTitleSubmit()
             }
         }
 
@@ -103,11 +105,15 @@ fun NoteDetailContentView(
                     style = TextStyle(Color.Black, fontWeight = FontWeight.Bold, fontSize = 20.sp),
                     modifier = modifier.padding(start = 10.dp, bottom = 5.dp)
                 )
+
                 Divider(color = colorResource(id = R.color.orange))
-                Text(
-                    text = description, style = TextStyle(
-                        Color.DarkGray, fontWeight = FontWeight.Medium, fontSize = 18.sp
-                    ), modifier = modifier.padding(10.dp, top = 10.dp)
+
+                EditDescriptionInput(
+                    description = description,
+                    onModifyText = onChangeDescription,
+                    onSubmitButton = {
+                        onTitleSubmit()
+                    }
                 )
             }
         }
@@ -115,45 +121,87 @@ fun NoteDetailContentView(
 }
 
 @Composable
-fun EditTitleInput(
-    modifier: Modifier = Modifier, title: String, onModifyText: (String) -> Unit
+fun EditDescriptionInput(
+    modifier: Modifier = Modifier,
+    description: String,
+    onModifyText: (String) -> Unit,
+    onSubmitButton: () -> Unit
 ) {
-    TextField(modifier = modifier
-        .fillMaxWidth()
-        .border(
-            BorderStroke(
-                width = 2.dp, color = colorResource(R.color.orange)
-            ), shape = RoundedCornerShape(10.dp)
-        ),
-        textStyle = TextStyle(
-            Color.Black,
-            fontSize = 24.sp,
-            fontWeight = FontWeight.Bold,
-            textAlign = TextAlign.Center
-        ),
-        singleLine = true,
+    TextField(
+        modifier = modifier.fillMaxWidth(),
+        value = description,
+        onValueChange = onModifyText,
         colors = TextFieldDefaults.textFieldColors(
             backgroundColor = Color.Transparent,
             focusedIndicatorColor = Color.Transparent,
             unfocusedIndicatorColor = Color.Transparent
         ),
         placeholder = {
-            Text(text = title)
+            Text(text = description)
         },
-        value = title,
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
-        onValueChange = {
-            onModifyText(it)
-        },
+        textStyle = TextStyle(
+            Color.DarkGray,
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Medium,
+            textAlign = TextAlign.Start
+        ),
+        keyboardActions = KeyboardActions(onDone = {
+            onSubmitButton()
+        })
+    )
+}
+
+@Composable
+fun EditTitleInput(
+    modifier: Modifier = Modifier,
+    title: String,
+    onModifyText: (String) -> Unit,
+    onSubmitButton: () -> Unit
+) {
+    TextField(
+        modifier = modifier
+            .fillMaxWidth()
+            .border(
+                BorderStroke(
+                    width = 2.dp, color = colorResource(R.color.orange)
+                ), shape = RoundedCornerShape(10.dp)
+            ),
+            textStyle = TextStyle(
+                Color.Black,
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center
+            ),
+            singleLine = true,
+            colors = TextFieldDefaults.textFieldColors(
+                backgroundColor = Color.Transparent,
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent
+            ),
+            placeholder = {
+                Text(text = title)
+            },
+            value = title,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+            onValueChange = {
+                onModifyText(it)
+            },
+            keyboardActions = KeyboardActions(onDone = {
+                onSubmitButton()
+            }),
     )
 }
 
 @Preview
 @Composable
 fun NoteDetailContentViewPreview() {
-    NoteDetailContentView(title = "text",
+    NoteDetailContentView(
+        title = "text",
         description = "description",
         insertDate = "2022 09/30 17:53",
         onChangeTitle = {},
-        onChangeDescription = {})
+        onChangeDescription = {},
+        onTitleSubmit = {},
+    )
 }

--- a/app/src/main/java/com/example/composetodoapp/presentation/components/NoteDetailComponents.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/components/NoteDetailComponents.kt
@@ -30,9 +30,11 @@ fun NoteDetailContentView(
     title: String,
     description: String,
     insertDate: String,
+    titleError: Boolean,
+    descriptionError: Boolean,
     onChangeTitle: (String) -> Unit,
     onChangeDescription: (String) -> Unit,
-    onTitleSubmit: () -> Unit
+    onTitleSubmit: () -> Unit,
 ) {
     Column(
         modifier = modifier
@@ -41,6 +43,7 @@ fun NoteDetailContentView(
             .padding(horizontal = 20.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        // Title
         Surface(
             modifier = modifier
                 .padding(top = 20.dp, bottom = 10.dp)
@@ -51,11 +54,12 @@ fun NoteDetailContentView(
                 )
                 .fillMaxWidth(),
         ) {
-            EditTitleInput(title = title, onModifyText = onChangeTitle) {
+            EditTitleInput(title = title, onModifyText = onChangeTitle, isError = titleError) {
                 onTitleSubmit()
             }
         }
 
+        // 작성, 수정 시간
         Row(
             modifier = modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween
         ) {
@@ -84,13 +88,17 @@ fun NoteDetailContentView(
             }
         }
 
+        // Description
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(top = 20.dp, bottom = 40.dp)
                 .clip(RoundedCornerShape(10.dp))
                 .border(
-                    BorderStroke(2.dp, colorResource(id = R.color.orange)),
+                    BorderStroke(
+                        2.dp,
+                        colorResource(id = if (descriptionError) R.color.red else R.color.orange)
+                    ),
                     shape = RoundedCornerShape(10.dp)
                 )
                 .background(color = Color.White), contentAlignment = Alignment.TopStart
@@ -116,6 +124,34 @@ fun NoteDetailContentView(
                     }
                 )
             }
+        }
+
+        OutlinedButton(
+            onClick = {},
+            shape = RoundedCornerShape(15),
+            border = BorderStroke(
+                1.dp,
+                /**
+                 * TODO:: 조건문 변경 필요
+                 * 조건
+                 * 1. title, description 이 비어있지 않고,
+                 * 2. 기존의 title 과 바뀐 title 이 서로 달라야함
+                 * 3. 기존의 description 과 바뀐 description 이 서로 달라야함
+                 */
+                if (title.isNotEmpty() && description.isNotEmpty()) Color.Red else Color.Gray
+            ),
+            /**
+             * TODO:: 조건문 변경 필요
+             * 조건
+             * 1. title, description 이 비어있지 않고,
+             * 2. 기존의 title 과 바뀐 title 이 서로 달라야함
+             * 3. 기존의 description 과 바뀐 description 이 서로 달라야함
+             */
+            enabled = title.isNotEmpty() && description.isNotEmpty(),
+            modifier = modifier,
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = Color.Red)
+        ) {
+            Text(text = stringResource(id = R.string.str_save))
         }
     }
 }
@@ -156,6 +192,7 @@ fun EditDescriptionInput(
 fun EditTitleInput(
     modifier: Modifier = Modifier,
     title: String,
+    isError: Boolean,
     onModifyText: (String) -> Unit,
     onSubmitButton: () -> Unit
 ) {
@@ -164,7 +201,8 @@ fun EditTitleInput(
             .fillMaxWidth()
             .border(
                 BorderStroke(
-                    width = 2.dp, color = colorResource(R.color.orange)
+                    width = 2.dp,
+                    color = colorResource(if (!isError) R.color.orange else R.color.red)
                 ), shape = RoundedCornerShape(10.dp)
             ),
             textStyle = TextStyle(
@@ -203,5 +241,7 @@ fun NoteDetailContentViewPreview() {
         onChangeTitle = {},
         onChangeDescription = {},
         onTitleSubmit = {},
+        titleError = false,
+        descriptionError = false,
     )
 }

--- a/app/src/main/java/com/example/composetodoapp/presentation/components/NoteDetailComponents.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/components/NoteDetailComponents.kt
@@ -30,6 +30,7 @@ fun NoteDetailContentView(
     title: String,
     description: String,
     insertDate: String,
+    updateDate: String,
     titleError: Boolean,
     descriptionError: Boolean,
     onChangeTitle: (String) -> Unit,
@@ -81,7 +82,7 @@ fun NoteDetailContentView(
                 shape = RoundedCornerShape(10.dp)
             ) {
                 Text(
-                    text = stringResource(id = R.string.note_update_at, insertDate),
+                    text = stringResource(id = R.string.note_update_at, updateDate),
                     style = TextStyle(color = Color.Gray, fontSize = 14.sp),
                     modifier = modifier.padding(10.dp)
                 )
@@ -124,34 +125,6 @@ fun NoteDetailContentView(
                     }
                 )
             }
-        }
-
-        OutlinedButton(
-            onClick = {},
-            shape = RoundedCornerShape(15),
-            border = BorderStroke(
-                1.dp,
-                /**
-                 * TODO:: 조건문 변경 필요
-                 * 조건
-                 * 1. title, description 이 비어있지 않고,
-                 * 2. 기존의 title 과 바뀐 title 이 서로 달라야함
-                 * 3. 기존의 description 과 바뀐 description 이 서로 달라야함
-                 */
-                if (title.isNotEmpty() && description.isNotEmpty()) Color.Red else Color.Gray
-            ),
-            /**
-             * TODO:: 조건문 변경 필요
-             * 조건
-             * 1. title, description 이 비어있지 않고,
-             * 2. 기존의 title 과 바뀐 title 이 서로 달라야함
-             * 3. 기존의 description 과 바뀐 description 이 서로 달라야함
-             */
-            enabled = title.isNotEmpty() && description.isNotEmpty(),
-            modifier = modifier,
-            colors = ButtonDefaults.outlinedButtonColors(contentColor = Color.Red)
-        ) {
-            Text(text = stringResource(id = R.string.str_save))
         }
     }
 }
@@ -238,6 +211,7 @@ fun NoteDetailContentViewPreview() {
         title = "text",
         description = "description",
         insertDate = "2022 09/30 17:53",
+        updateDate = "2022 10/04 09:46",
         onChangeTitle = {},
         onChangeDescription = {},
         onTitleSubmit = {},

--- a/app/src/main/java/com/example/composetodoapp/presentation/navigation/NoteNavigation.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/navigation/NoteNavigation.kt
@@ -91,6 +91,12 @@ fun NoteNavigation(viewModel: NoteViewModel, coroutineScope: CoroutineScope) {
                     }
 
                     viewModel.currentNote.value?.let {
+                        if (customDialogTitle.value.second == R.string.dialog_modify_title) {
+                            viewModel.updateNote(it)
+                            scaffoldState.snackbarHostState.showSnackbar("${it.title}를 수정하였습니다.")
+                            return@launch
+                        }
+
                         viewModel.removeNote(it)
                         scaffoldState.snackbarHostState.showSnackbar("${it.title}를 삭제하였습니다.")
                     }

--- a/app/src/main/java/com/example/composetodoapp/presentation/navigation/NoteNavigation.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/navigation/NoteNavigation.kt
@@ -33,6 +33,10 @@ fun NoteNavigation(viewModel: NoteViewModel, coroutineScope: CoroutineScope) {
     val customDialogConfirmText = viewModel.customDialogConfirmText.collectAsState()
     val customDialogCancelText = viewModel.customDialogCancelText.collectAsState()
 
+    // NoteDetails
+    val isDescriptionError = viewModel.detailDescriptionError.collectAsState()
+    val isTitleError = viewModel.detailTitleError.collectAsState()
+
     return NavHost(navController = navController, startDestination = NavigationType.HOMESCREEN.name) {
         composable(NavigationType.HOMESCREEN.name) {
             NoteScreen(
@@ -54,10 +58,14 @@ fun NoteNavigation(viewModel: NoteViewModel, coroutineScope: CoroutineScope) {
             NoteDetailScreen(
                 navController = navController,
                 note.value,
+                isTitleError = isTitleError.value,
+                isDescriptionError = isDescriptionError.value,
                 setCustomDialogCancelText = viewModel::setCustomDialogCancelText,
                 setCustomDialogConfirmText = viewModel::setCustomDialogConfirmText,
                 setCustomDialogTitle = viewModel::setCustomDialogTitle,
                 setCurrentNote = viewModel::setCurrentNote,
+                onSetDescriptionError = viewModel::setDetailDescriptionError,
+                onSetTitleError = viewModel::setDetailTitleError
             )
         }
 

--- a/app/src/main/java/com/example/composetodoapp/presentation/screen/NoteDetailScreen.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/screen/NoteDetailScreen.kt
@@ -1,17 +1,22 @@
 package com.example.composetodoapp.presentation.screen
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Save
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -23,6 +28,7 @@ import com.example.composetodoapp.domain.model.Note
 import com.example.composetodoapp.presentation.components.NoteDetailContentView
 import com.example.composetodoapp.presentation.navigation.NavigationType
 import com.example.composetodoapp.presentation.utils.timeFormatter
+import org.joda.time.DateTime
 
 @ExperimentalComposeUiApi
 @Composable
@@ -44,6 +50,11 @@ fun NoteDetailScreen(
         val title = data.title
         val description = data.description
         val insertDate = timeFormatter("YY-MM-dd HH:mm").print(data.entryDate)
+        val updateDate = if (data.updateDate != null) {
+            timeFormatter("YY-MM-dd HH:mm").print(data.updateDate)
+        } else {
+            " - "
+        }
 
         val modifyTitle = remember {
             mutableStateOf(title)
@@ -51,6 +62,15 @@ fun NoteDetailScreen(
         val modifyDescription = remember {
             mutableStateOf(description)
         }
+
+        /**
+         * Title 과 Description 의 내용이 비어있거나,
+         * Title 과 Description 의 내용이 변경되지 않으면 -> false
+         * Title 과 Description 의 내용이 비어있지 않고,
+         * Title 과 Description 의 내용이 변경되었으면 -> true
+         */
+        val isSaveEnable =
+            (modifyTitle.value.isNotEmpty() && modifyDescription.value.isNotEmpty()) && (title != modifyTitle.value || description != modifyDescription.value)
 
         Scaffold(topBar = {
             TopAppBar(backgroundColor = Color.White, title = {
@@ -64,18 +84,46 @@ fun NoteDetailScreen(
                     Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Back")
                 }
             }, actions = {
-                IconButton(onClick = {
-                    setCurrentNote(data)
-                    setCustomDialogTitle(data.title to R.string.dialog_title)
-                    setCustomDialogConfirmText(R.string.str_delete)
-                    setCustomDialogCancelText(R.string.str_cancel)
-                    navController.navigate(route = NavigationType.CUSTOMDIALOG.name)
-                }) {
-                    Icon(
-                        imageVector = Icons.Default.Delete,
-                        contentDescription = "Search",
-                        modifier = Modifier.padding(end = 10.dp)
-                    )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    IconButton(
+                        onClick = {
+                            setCurrentNote(Note(
+                                id = data.id,
+                                title = modifyTitle.value,
+                                description = modifyDescription.value,
+                                entryDate = data.entryDate,
+                                updateDate = DateTime.now()
+                            ))
+                            setCustomDialogTitle(data.title to R.string.dialog_modify_title)
+                            setCustomDialogConfirmText(R.string.str_modify)
+                            setCustomDialogCancelText(R.string.str_cancel)
+                            navController.navigate(route = NavigationType.CUSTOMDIALOG.name)
+                        }, enabled = isSaveEnable
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Save,
+                            contentDescription = "Save",
+                            modifier = Modifier.padding(end = 5.dp),
+                            tint = if (isSaveEnable) colorResource(id = R.color.orange) else Color.DarkGray
+                        )
+                    }
+
+                    IconButton(onClick = {
+                        setCurrentNote(data)
+                        setCustomDialogTitle(data.title to R.string.dialog_title)
+                        setCustomDialogConfirmText(R.string.str_delete)
+                        setCustomDialogCancelText(R.string.str_cancel)
+                        navController.navigate(route = NavigationType.CUSTOMDIALOG.name)
+                    }) {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = "Delete",
+                            modifier = Modifier.padding(end = 10.dp)
+                        )
+                    }
                 }
             })
         }) {
@@ -83,6 +131,7 @@ fun NoteDetailScreen(
                 title = modifyTitle.value,
                 description = modifyDescription.value,
                 insertDate = insertDate,
+                updateDate = updateDate,
                 titleError = isTitleError,
                 descriptionError = isDescriptionError,
                 onChangeTitle = {

--- a/app/src/main/java/com/example/composetodoapp/presentation/screen/NoteDetailScreen.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/screen/NoteDetailScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
@@ -33,6 +35,14 @@ fun NoteDetailScreen(
         val title = data.title
         val description = data.description
         val insertDate = timeFormatter("YY-MM-dd HH:mm").print(data.entryDate)
+
+        val modifyTitle = remember {
+            mutableStateOf(title)
+        }
+        val modifyDescription = remember {
+            mutableStateOf(description)
+        }
+
         Scaffold(topBar = {
             TopAppBar(backgroundColor = Color.White, title = {
                 Text(
@@ -61,10 +71,15 @@ fun NoteDetailScreen(
             })
         }) {
             NoteDetailContentView(
-                title = title,
-                description = description,
-                insertDate = insertDate
-            )
+                title = modifyTitle.value,
+                description = modifyDescription.value,
+                insertDate = insertDate,
+                onChangeTitle = {
+                    modifyTitle.value = it
+                }
+            ) {
+                modifyDescription.value = it
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/composetodoapp/presentation/screen/NoteDetailScreen.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/screen/NoteDetailScreen.kt
@@ -8,8 +8,10 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -22,6 +24,7 @@ import com.example.composetodoapp.presentation.components.NoteDetailContentView
 import com.example.composetodoapp.presentation.navigation.NavigationType
 import com.example.composetodoapp.presentation.utils.timeFormatter
 
+@ExperimentalComposeUiApi
 @Composable
 fun NoteDetailScreen(
     navController: NavController,
@@ -32,6 +35,8 @@ fun NoteDetailScreen(
     setCurrentNote: (Note) -> Unit,
 ) {
     note?.let { data ->
+        val keyboardContainer = LocalSoftwareKeyboardController.current
+
         val title = data.title
         val description = data.description
         val insertDate = timeFormatter("YY-MM-dd HH:mm").print(data.entryDate)
@@ -76,9 +81,12 @@ fun NoteDetailScreen(
                 insertDate = insertDate,
                 onChangeTitle = {
                     modifyTitle.value = it
+                },
+                onChangeDescription = {
+                    modifyDescription.value = it
                 }
             ) {
-                modifyDescription.value = it
+                keyboardContainer?.hide()
             }
         }
     }

--- a/app/src/main/java/com/example/composetodoapp/presentation/screen/NoteDetailScreen.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/screen/NoteDetailScreen.kt
@@ -29,10 +29,14 @@ import com.example.composetodoapp.presentation.utils.timeFormatter
 fun NoteDetailScreen(
     navController: NavController,
     note: Note?,
+    isTitleError: Boolean,
+    isDescriptionError: Boolean,
     setCustomDialogTitle: (Pair<String, Int?>) -> Unit,
     setCustomDialogConfirmText: (Int) -> Unit,
     setCustomDialogCancelText: (Int) -> Unit,
     setCurrentNote: (Note) -> Unit,
+    onSetTitleError: (Boolean) -> Unit,
+    onSetDescriptionError: (Boolean) -> Unit
 ) {
     note?.let { data ->
         val keyboardContainer = LocalSoftwareKeyboardController.current
@@ -79,12 +83,16 @@ fun NoteDetailScreen(
                 title = modifyTitle.value,
                 description = modifyDescription.value,
                 insertDate = insertDate,
+                titleError = isTitleError,
+                descriptionError = isDescriptionError,
                 onChangeTitle = {
+                    onSetTitleError(it.isEmpty())
                     modifyTitle.value = it
                 },
                 onChangeDescription = {
+                    onSetDescriptionError(it.isEmpty())
                     modifyDescription.value = it
-                }
+                },
             ) {
                 keyboardContainer?.hide()
             }

--- a/app/src/main/java/com/example/composetodoapp/presentation/ui/NoteViewModel.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/ui/NoteViewModel.kt
@@ -23,6 +23,19 @@ class NoteViewModel @Inject constructor(
     private val requestSaveNoteUseCase: RequestSaveNoteUseCase,
     private val requestUpdateNoteUseCase: RequestUpdateNoteUseCase
 ) : ViewModel() {
+    private val _detailTitleError = MutableStateFlow(false)
+    val detailTitleError = _detailTitleError.asStateFlow()
+
+    fun setDetailTitleError(isError: Boolean) {
+        _detailTitleError.value = isError
+    }
+
+    private val _detailDescriptionError = MutableStateFlow(false)
+    val detailDescriptionError = _detailDescriptionError.asStateFlow()
+
+    fun setDetailDescriptionError(isError: Boolean) {
+        _detailDescriptionError.value = isError
+    }
 
     private val _customDialogTitle = MutableStateFlow<Pair<String, Int?>>("" to null)
     val customDialogTitle = _customDialogTitle.asStateFlow()

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,4 +8,5 @@
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
     <color name="orange">#FFAB00</color>
+    <color name="red">#FFFF0000</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,6 @@
     <string name="str_cancel">취소</string>
     <string name="str_delete">삭제</string>
     <string name="str_save">저장</string>
+    <string name="str_modify">수정</string>
+    <string name="dialog_modify_title">%1$s를 \n 수정 하시겠습니까?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,4 +9,5 @@
     <string name="delete_note">$1$s를 삭제 하였습니다.</string>
     <string name="str_cancel">취소</string>
     <string name="str_delete">삭제</string>
+    <string name="str_save">저장</string>
 </resources>


### PR DESCRIPTION
## 🍎 NoteDetailScreen InputText 추가
### 🚩 1. NoteDetailScreen `Note Title` 영역 InputText 로 교체
- 포커스 `Submit` 버튼 클릭 시 keyboard hide 작업 완료
- 빈 값일 경우 `Error` Board color Red 표시 작업 완료

### 🚩 2. NoteDetailScreen `Note Description` 영역 InputText 로 교체
- 빈 값일 경우 `Error` Board color Red 표시 작업 완료


## 🍎 노트 수정 기능 추가
### 🚩 1. NoteEntity 데이터 구조 변경 및 추가
- `id` : UUID 를 통해 랜덤하게 생성되고 있던 `primaryKey` -> `autoGenerate` 로 변경
- `updateDate` : 수정 시간 필드 추가

### 🚩 2. 수정 기능 추가
- `NoteDetailScreen` 상단의 Save 버튼 클릭 시 `Room` 에 해당 Note의 변경사항을 반형하여 수정
- `NoteDetailScreen` 수정 버튼의 `enable` 조건
> - 1. Title 과 Description 의 내용이 비어있거나, Title 과 Description 의 내용이 변경되지 않으면 `false`
> - 2. Title 과 Description 의 내용이 비어있지 않고, Title 과 Description 의 내용이 변경되었으면 'true'
>>
``` kotlin
 val isSaveEnable =
            (modifyTitle.value.isNotEmpty() && modifyDescription.value.isNotEmpty()) && (title != modifyTitle.value || description != modifyDescription.value)
```