### PR TITLE
노트 상세 > 이미지 수정 및 삭제 기능 추가

### DIFF
--- a/app/src/main/java/com/example/composetodoapp/presentation/components/NoteDetailComponents.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/components/NoteDetailComponents.kt
@@ -1,18 +1,24 @@
 package com.example.composetodoapp.presentation.components
 
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
+import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Image
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -23,108 +29,158 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.composetodoapp.R
+import com.example.composetodoapp.presentation.utils.toImageBitmap
 
 @Composable
 fun NoteDetailContentView(
     modifier: Modifier = Modifier,
+    descriptionFocusRequester: FocusRequester,
     title: String,
     description: String,
     insertDate: String,
     updateDate: String,
     titleError: Boolean,
     descriptionError: Boolean,
+    modifyImageBitmap: ByteArray?,
     onChangeTitle: (String) -> Unit,
     onChangeDescription: (String) -> Unit,
     onTitleSubmit: () -> Unit,
+    onModifyImage: () -> Unit,
+    onRemoveImage: () -> Unit,
+    onResetDescription: () -> Unit
 ) {
-    Column(
-        modifier = modifier
-            .fillMaxHeight()
-            .fillMaxWidth()
-            .padding(horizontal = 20.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        // Title
+    // Image
+    if (modifyImageBitmap != null) {
         Surface(
             modifier = modifier
-                .padding(top = 20.dp, bottom = 10.dp)
-                .clip(
-                    RoundedCornerShape(
-                        10.dp
-                    )
-                )
-                .fillMaxWidth(),
+                .padding(top = 15.dp)
+                .size(300.dp),
+            shape = RectangleShape,
+            elevation = 4.dp
         ) {
-            EditTitleInput(title = title, onModifyText = onChangeTitle, isError = titleError) {
-                onTitleSubmit()
-            }
+            Image(
+                bitmap = modifyImageBitmap.toImageBitmap().asImageBitmap(),
+                contentDescription = "Image",
+            )
         }
+    }
 
-        // 작성, 수정 시간
-        Row(
-            modifier = modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween
+    // Title
+    Surface(
+        modifier = modifier
+            .padding(top = 20.dp, bottom = 10.dp)
+            .clip(
+                RoundedCornerShape(
+                    10.dp
+                )
+            )
+            .fillMaxWidth(),
+    ) {
+        EditTitleInput(title = title, onModifyText = onChangeTitle, isError = titleError) {
+            onTitleSubmit()
+        }
+    }
+
+    // 작성, 수정 시간
+    Row(
+        modifier = modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Surface(
+            modifier = modifier.padding(end = 5.dp),
+            color = Color.White,
+            border = BorderStroke(1.dp, colorResource(id = R.color.orange)),
+            shape = RoundedCornerShape(10.dp)
         ) {
-            Surface(
-                modifier = modifier.padding(end = 5.dp),
-                color = Color.White,
-                border = BorderStroke(1.dp, colorResource(id = R.color.orange)),
-                shape = RoundedCornerShape(10.dp)
-            ) {
-                Text(
-                    text = stringResource(id = R.string.note_create_at, insertDate),
-                    style = TextStyle(color = Color.Gray, fontSize = 14.sp),
-                    modifier = modifier.padding(10.dp)
-                )
-            }
-            Surface(
-                color = Color.White,
-                border = BorderStroke(1.dp, colorResource(id = R.color.orange)),
-                shape = RoundedCornerShape(10.dp)
-            ) {
-                Text(
-                    text = stringResource(id = R.string.note_update_at, updateDate),
-                    style = TextStyle(color = Color.Gray, fontSize = 14.sp),
-                    modifier = modifier.padding(10.dp)
-                )
-            }
+            Text(
+                text = stringResource(id = R.string.note_create_at, insertDate),
+                style = TextStyle(color = Color.Gray, fontSize = 14.sp),
+                modifier = modifier.padding(10.dp)
+            )
         }
+        Surface(
+            color = Color.White,
+            border = BorderStroke(1.dp, colorResource(id = R.color.orange)),
+            shape = RoundedCornerShape(10.dp)
+        ) {
+            Text(
+                text = stringResource(id = R.string.note_update_at, updateDate),
+                style = TextStyle(color = Color.Gray, fontSize = 14.sp),
+                modifier = modifier.padding(10.dp)
+            )
+        }
+    }
 
-        // Description
-        Box(
-            modifier = Modifier
+    // Description
+    BoxWithConstraints(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(500.dp)
+            .padding(top = 20.dp, bottom = 40.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .border(
+                BorderStroke(
+                    2.dp,
+                    colorResource(id = if (descriptionError) R.color.red else R.color.orange)
+                ),
+                shape = RoundedCornerShape(10.dp)
+            )
+            .background(color = Color.White), contentAlignment = Alignment.TopStart
+    ) {
+        Column(
+            modifier = modifier
                 .fillMaxSize()
-                .padding(top = 20.dp, bottom = 40.dp)
-                .clip(RoundedCornerShape(10.dp))
-                .border(
-                    BorderStroke(
-                        2.dp,
-                        colorResource(id = if (descriptionError) R.color.red else R.color.orange)
-                    ),
-                    shape = RoundedCornerShape(10.dp)
-                )
-                .background(color = Color.White), contentAlignment = Alignment.TopStart
+                .padding(10.dp)
         ) {
-            Column(
+            Text(
+                text = "내용",
+                style = TextStyle(Color.Black, fontWeight = FontWeight.Bold, fontSize = 20.sp),
+                modifier = modifier.padding(start = 10.dp, bottom = 5.dp)
+            )
+
+            Divider(color = colorResource(id = R.color.orange))
+
+            EditDescriptionInput(
+                description = description,
+                onModifyText = onChangeDescription,
+                focusRequester = descriptionFocusRequester
+            )
+        }
+
+        if (!descriptionError) {
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = "Close",
                 modifier = modifier
-                    .fillMaxSize()
-                    .padding(10.dp)
-            ) {
-                Text(
-                    text = "내용",
-                    style = TextStyle(Color.Black, fontWeight = FontWeight.Bold, fontSize = 20.sp),
-                    modifier = modifier.padding(start = 10.dp, bottom = 5.dp)
-                )
+                    .align(Alignment.TopEnd)
+                    .padding(top = 60.dp, end = 10.dp)
+                    .clickable { onResetDescription() },
+                tint = colorResource(id = R.color.orange)
+            )
+        }
+    }
 
-                Divider(color = colorResource(id = R.color.orange))
+    // 이미지 수정 및 삭제
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(start = 10.dp, top = 10.dp, end = 10.dp, bottom = 30.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Row(
+            modifier = modifier.wrapContentHeight().wrapContentWidth().clickable { onModifyImage() },
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(imageVector = Icons.Default.Image, contentDescription = "Image Modify")
+            Text(text = "이미지 수정", textAlign = TextAlign.Center)
+        }
 
-                EditDescriptionInput(
-                    description = description,
-                    onModifyText = onChangeDescription,
-                    onSubmitButton = {
-                        onTitleSubmit()
-                    }
-                )
-            }
+        Row(
+            modifier = modifier.wrapContentHeight().wrapContentWidth().clickable { onRemoveImage() },
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(imageVector = Icons.Default.Delete, contentDescription = "Image Delete")
+            Text(text = "이미지 삭제", textAlign = TextAlign.Center)
         }
     }
 }
@@ -133,11 +189,14 @@ fun NoteDetailContentView(
 fun EditDescriptionInput(
     modifier: Modifier = Modifier,
     description: String,
-    onModifyText: (String) -> Unit,
-    onSubmitButton: () -> Unit
+    focusRequester: FocusRequester,
+    onModifyText: (String) -> Unit
 ) {
     TextField(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(bottom = 20.dp)
+            .focusRequester(focusRequester = focusRequester),
         value = description,
         onValueChange = onModifyText,
         colors = TextFieldDefaults.textFieldColors(
@@ -154,10 +213,7 @@ fun EditDescriptionInput(
             fontSize = 18.sp,
             fontWeight = FontWeight.Medium,
             textAlign = TextAlign.Start
-        ),
-        keyboardActions = KeyboardActions(onDone = {
-            onSubmitButton()
-        })
+        )
     )
 }
 
@@ -178,44 +234,32 @@ fun EditTitleInput(
                     color = colorResource(if (!isError) R.color.orange else R.color.red)
                 ), shape = RoundedCornerShape(10.dp)
             ),
-            textStyle = TextStyle(
-                Color.Black,
-                fontSize = 24.sp,
-                fontWeight = FontWeight.Bold,
-                textAlign = TextAlign.Center
-            ),
-            singleLine = true,
-            colors = TextFieldDefaults.textFieldColors(
-                backgroundColor = Color.Transparent,
-                focusedIndicatorColor = Color.Transparent,
-                unfocusedIndicatorColor = Color.Transparent
-            ),
-            placeholder = {
-                Text(text = title)
-            },
-            value = title,
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
-            onValueChange = {
-                onModifyText(it)
-            },
-            keyboardActions = KeyboardActions(onDone = {
-                onSubmitButton()
-            }),
+        textStyle = TextStyle(
+            Color.Black,
+            fontSize = 24.sp,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center
+        ),
+        singleLine = true,
+        colors = TextFieldDefaults.textFieldColors(
+            backgroundColor = Color.Transparent,
+            focusedIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent
+        ),
+        placeholder = {
+            Text(text = title)
+        },
+        value = title,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+        onValueChange = {
+            onModifyText(it)
+        },
+        keyboardActions = KeyboardActions(onDone = {
+            onSubmitButton()
+        }),
     )
 }
 
 @Preview
 @Composable
-fun NoteDetailContentViewPreview() {
-    NoteDetailContentView(
-        title = "text",
-        description = "description",
-        insertDate = "2022 09/30 17:53",
-        updateDate = "2022 10/04 09:46",
-        onChangeTitle = {},
-        onChangeDescription = {},
-        onTitleSubmit = {},
-        titleError = false,
-        descriptionError = false,
-    )
-}
+fun NoteDetailContentViewPreview() {}

--- a/app/src/main/java/com/example/composetodoapp/presentation/components/NoteWriteComponents.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/components/NoteWriteComponents.kt
@@ -26,14 +26,12 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
 import com.example.composetodoapp.R
 import com.example.composetodoapp.presentation.utils.addFocusCleaner
 
 @Composable
 fun NoteWriteContentView(
     modifier: Modifier = Modifier,
-    navController: NavController,
     descriptionFocusRequester: FocusRequester,
     focusManager: FocusManager,
     title: String,
@@ -95,9 +93,7 @@ fun NoteWriteContentView(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.Center
             ) {
-                IconButton(onClick = { /*TODO*/ }) {
-                    Icon(imageVector = Icons.Default.Image, contentDescription = "이미지")
-                }
+                Icon(imageVector = Icons.Default.Image, contentDescription = "이미지")
                 Text(text = "이미지 첨부", textAlign = TextAlign.Center)
             }
 

--- a/app/src/main/java/com/example/composetodoapp/presentation/navigation/NoteNavigation.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/navigation/NoteNavigation.kt
@@ -1,5 +1,6 @@
 package com.example.composetodoapp.presentation.navigation
 
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -35,8 +36,7 @@ fun NoteNavigation(viewModel: NoteViewModel, coroutineScope: CoroutineScope) {
     val customDialogCancelText = viewModel.customDialogCancelText.collectAsState()
 
     // NoteDetails
-    val isDescriptionError = viewModel.detailDescriptionError.collectAsState()
-    val isTitleError = viewModel.detailTitleError.collectAsState()
+    val noteDetailScrollState = rememberScrollState()
 
     return NavHost(navController = navController, startDestination = NavigationType.HOME_SCREEN.name) {
         composable(NavigationType.HOME_SCREEN.name) {
@@ -57,14 +57,13 @@ fun NoteNavigation(viewModel: NoteViewModel, coroutineScope: CoroutineScope) {
             NoteDetailScreen(
                 navController = navController,
                 note.value,
-                isTitleError = isTitleError.value,
-                isDescriptionError = isDescriptionError.value,
+                scrollState = noteDetailScrollState,
+                scaffoldState = scaffoldState,
+                coroutineScope = coroutineScope,
                 setCustomDialogCancelText = viewModel::setCustomDialogCancelText,
                 setCustomDialogConfirmText = viewModel::setCustomDialogConfirmText,
                 setCustomDialogTitle = viewModel::setCustomDialogTitle,
                 setCurrentNote = viewModel::setCurrentNote,
-                onSetDescriptionError = viewModel::setDetailDescriptionError,
-                onSetTitleError = viewModel::setDetailTitleError
             )
         }
 

--- a/app/src/main/java/com/example/composetodoapp/presentation/screen/NoteDetailScreen.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/screen/NoteDetailScreen.kt
@@ -1,8 +1,15 @@
 package com.example.composetodoapp.presentation.screen
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.padding
+import android.app.Activity
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.drawable.Drawable
+import android.provider.MediaStore
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -14,39 +21,45 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import com.bumptech.glide.Glide
+import com.bumptech.glide.request.target.CustomTarget
+import com.bumptech.glide.request.transition.Transition
 import com.example.composetodoapp.R
 import com.example.composetodoapp.domain.model.Note
 import com.example.composetodoapp.presentation.components.NoteDetailContentView
 import com.example.composetodoapp.presentation.navigation.NavigationType
 import com.example.composetodoapp.presentation.utils.timeFormatter
+import com.example.composetodoapp.presentation.utils.toBitMap
+import com.example.composetodoapp.presentation.utils.toByteArray
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import org.joda.time.DateTime
+import kotlin.math.max
 
 @ExperimentalComposeUiApi
 @Composable
 fun NoteDetailScreen(
     navController: NavController,
     note: Note?,
-    isTitleError: Boolean,
-    isDescriptionError: Boolean,
+    scrollState: ScrollState,
+    scaffoldState: ScaffoldState,
+    coroutineScope: CoroutineScope,
     setCustomDialogTitle: (Pair<String, Int?>) -> Unit,
     setCustomDialogConfirmText: (Int) -> Unit,
     setCustomDialogCancelText: (Int) -> Unit,
     setCurrentNote: (Note) -> Unit,
-    onSetTitleError: (Boolean) -> Unit,
-    onSetDescriptionError: (Boolean) -> Unit
 ) {
     note?.let { data ->
-        val keyboardContainer = LocalSoftwareKeyboardController.current
-
         val title = data.title
         val description = data.description
         val insertDate = timeFormatter("YY-MM-dd HH:mm").print(data.entryDate)
@@ -55,6 +68,65 @@ fun NoteDetailScreen(
         } else {
             " - "
         }
+        val image = data.image
+
+        val modifyImage = remember {
+            mutableStateOf(image)
+        }
+
+        val context = LocalContext.current
+
+        val takePhotoFormAlbumLauncher =
+            rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+                if (result.resultCode == Activity.RESULT_OK) {
+                    result.data?.data?.let {
+
+                        val bitmap = it.toBitMap(context)
+                        val ratio = if (max(bitmap.width.toDouble(), bitmap.height.toDouble()) > 1270) {
+                            when {
+                                bitmap.width > bitmap.height -> {
+                                    1270.0 / bitmap.width.toDouble()
+                                }
+                                else -> {
+                                    1270.0 / bitmap.height.toDouble()
+                                }
+                            }
+                        } else {
+                            1.0
+                        }
+
+                        val width = (bitmap.width.toDouble() * ratio).toInt()
+                        val height = (bitmap.height.toDouble() * ratio).toInt()
+
+                        Glide.with(context)
+                            .asBitmap()
+                            .load(bitmap)
+                            .override(width, height)
+                            .into(object : CustomTarget<Bitmap>() {
+                                override fun onResourceReady(
+                                    resource: Bitmap,
+                                    transition: Transition<in Bitmap>?
+                                ) {
+                                    modifyImage.value = resource.toByteArray()
+
+                                    if (bitmap != resource) {
+                                        bitmap.recycle()
+                                    }
+                                }
+
+                                override fun onLoadCleared(placeholder: Drawable?) {}
+                            })
+                    } ?: run {
+                        coroutineScope.launch {
+                            scaffoldState.snackbarHostState.showSnackbar("이미지 가져오기에 실패하였습니다. 잠시 후 다시 시도해 주세요.")
+                        }
+                    }
+                } else if (result.resultCode != Activity.RESULT_CANCELED) {
+                    coroutineScope.launch {
+                        scaffoldState.snackbarHostState.showSnackbar("알 수 없는 오류가 발생하였습니다. 잠시 후 다시 시도해 주세요.")
+                    }
+                }
+            }
 
         val modifyTitle = remember {
             mutableStateOf(title)
@@ -63,6 +135,15 @@ fun NoteDetailScreen(
             mutableStateOf(description)
         }
 
+        val descriptionFocusRequester = remember {
+            FocusRequester()
+        }
+
+        val isTitleError = modifyTitle.value.isEmpty()
+        val isDescriptionError = modifyDescription.value.isEmpty()
+
+        val focusManager = LocalFocusManager.current
+
         /**
          * Title 과 Description 의 내용이 비어있거나,
          * Title 과 Description 의 내용이 변경되지 않으면 -> false
@@ -70,14 +151,14 @@ fun NoteDetailScreen(
          * Title 과 Description 의 내용이 변경되었으면 -> true
          */
         val isSaveEnable =
-            (modifyTitle.value.isNotEmpty() && modifyDescription.value.isNotEmpty()) && (title != modifyTitle.value || description != modifyDescription.value)
+            (modifyTitle.value.isNotEmpty() && modifyDescription.value.isNotEmpty()) && (title != modifyTitle.value || description != modifyDescription.value || !image.contentEquals(
+                modifyImage.value
+            ))
 
         Scaffold(topBar = {
             TopAppBar(backgroundColor = Color.White, title = {
                 Text(
-                    text = stringResource(
-                        id = R.string.note_detail_title, title
-                    ), style = TextStyle(fontWeight = FontWeight.Bold, fontSize = 24.sp)
+                    text = title, style = TextStyle(fontWeight = FontWeight.Bold, fontSize = 24.sp)
                 )
             }, navigationIcon = {
                 IconButton(onClick = { navController.popBackStack() }) {
@@ -95,7 +176,8 @@ fun NoteDetailScreen(
                                 title = modifyTitle.value,
                                 description = modifyDescription.value,
                                 entryDate = data.entryDate,
-                                updateDate = DateTime.now()
+                                updateDate = DateTime.now(),
+                                image = modifyImage.value
                             ))
                             setCustomDialogTitle(data.title to R.string.dialog_modify_title)
                             setCustomDialogConfirmText(R.string.str_modify)
@@ -127,23 +209,58 @@ fun NoteDetailScreen(
                 }
             })
         }) {
-            NoteDetailContentView(
-                title = modifyTitle.value,
-                description = modifyDescription.value,
-                insertDate = insertDate,
-                updateDate = updateDate,
-                titleError = isTitleError,
-                descriptionError = isDescriptionError,
-                onChangeTitle = {
-                    onSetTitleError(it.isEmpty())
-                    modifyTitle.value = it
-                },
-                onChangeDescription = {
-                    onSetDescriptionError(it.isEmpty())
-                    modifyDescription.value = it
-                },
+            Column(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp)
+                    .verticalScroll(scrollState),
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                keyboardContainer?.hide()
+                NoteDetailContentView(
+                    descriptionFocusRequester = descriptionFocusRequester,
+                    title = modifyTitle.value,
+                    description = modifyDescription.value,
+                    insertDate = insertDate,
+                    updateDate = updateDate,
+                    titleError = isTitleError,
+                    descriptionError = isDescriptionError,
+                    modifyImageBitmap = modifyImage.value,
+                    onChangeTitle = {
+                        modifyTitle.value = it
+                    },
+                    onTitleSubmit = { descriptionFocusRequester.requestFocus() },
+                    onChangeDescription = {
+                        modifyDescription.value = it.take(250)
+                        if (it.length > 250) {
+                            focusManager.clearFocus()
+                        }
+                    },
+                    onModifyImage = {
+                        takePhotoFormAlbumLauncher.launch(
+                            Intent(
+                                Intent.ACTION_GET_CONTENT,
+                                MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+                            ).apply {
+                                type = "image/*"
+                                action = Intent.ACTION_GET_CONTENT
+                                putExtra(
+                                    Intent.EXTRA_MIME_TYPES,
+                                    arrayOf("image/jpeg", "image/png", "image/bmp", "image/webp")
+                                )
+                                putExtra(Intent.EXTRA_ALLOW_MULTIPLE, false)
+                            }
+                        )
+                    },
+                    onRemoveImage = {
+                        modifyImage.value = null
+                        coroutineScope.launch {
+                            scaffoldState.snackbarHostState.showSnackbar("이미지가 삭제되었습니다.")
+                        }
+                    }
+                ) {
+                    modifyDescription.value = ""
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/composetodoapp/presentation/screen/NoteWriteScreen.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/screen/NoteWriteScreen.kt
@@ -158,7 +158,6 @@ fun NoteWriteScreen(
         )
     }) {
         NoteWriteContentView(
-            navController = navController,
             descriptionFocusRequester = descriptionFocusRequester,
             focusManager = focusManager,
             title = title.value,

--- a/app/src/main/java/com/example/composetodoapp/presentation/ui/NoteViewModel.kt
+++ b/app/src/main/java/com/example/composetodoapp/presentation/ui/NoteViewModel.kt
@@ -23,20 +23,6 @@ class NoteViewModel @Inject constructor(
     private val requestSaveNoteUseCase: RequestSaveNoteUseCase,
     private val requestUpdateNoteUseCase: RequestUpdateNoteUseCase
 ) : ViewModel() {
-    private val _detailTitleError = MutableStateFlow(false)
-    val detailTitleError = _detailTitleError.asStateFlow()
-
-    fun setDetailTitleError(isError: Boolean) {
-        _detailTitleError.value = isError
-    }
-
-    private val _detailDescriptionError = MutableStateFlow(false)
-    val detailDescriptionError = _detailDescriptionError.asStateFlow()
-
-    fun setDetailDescriptionError(isError: Boolean) {
-        _detailDescriptionError.value = isError
-    }
-
     private val _customDialogTitle = MutableStateFlow<Pair<String, Int?>>("" to null)
     val customDialogTitle = _customDialogTitle.asStateFlow()
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,6 @@
     <string name="dialog_title">%1$s를 \n 삭제 하시겠습니까?</string>
     <string name="dialog_all_remove_title">전체 메모를 \n 삭제 하시겠습니까?</string>
     <string name="note_cnt">목록 : "<b>"%1$d"</b>" 개</string>
-    <string name="note_detail_title">%1$s 노트 상세</string>
     <string name="note_create_at">작성 : %1$s</string>
     <string name="note_update_at">수정 : %1$s</string>
     <string name="delete_note">$1$s를 삭제 하였습니다.</string>


### PR DESCRIPTION
## 🍎 노트 상세 > 이미지 수정 및 삭제 기능 추가
### 🚩 1. 노트 상세 이미지 보이도록 디자인 변경
- 기존 : 이미지 보이지 않음
- 수정 : 최상단에 이미지 추가 및 최하단 이미지 수정/삭제 버튼 생성

### 🚩 2. 노트 상세 및 NoteViewModel 불필요 코드 정리
- NoteViewModel 내부에 TextInput 의 Border Error 표시를 위해 존재하던 프로퍼티 및 set 함수 제거